### PR TITLE
Clang-tidy and C++20 support

### DIFF
--- a/include/conduit/conduit-utility.h
+++ b/include/conduit/conduit-utility.h
@@ -92,7 +92,7 @@ struct TupleCat<std::tuple<T...>, std::tuple<U...>, V...> {
 inline std::string demangle(const char *name)
 {
     int status = 0;
-    auto s = abi::__cxa_demangle(name, nullptr, 0, &status);
+    auto s = abi::__cxa_demangle(name, nullptr, nullptr, &status);
     if (status != 0) {
         return name;
     }

--- a/include/conduit/conduit.h
+++ b/include/conduit/conduit.h
@@ -147,7 +147,7 @@ namespace detail
     }
 
     template <typename T>
-    typename std::enable_if<!detail::has_putto_operator<T>::value>::type print_arg(std::ostream &stream, __attribute__ ((unused)) T &&t)
+    typename std::enable_if<!detail::has_putto_operator<T>::value>::type print_arg(std::ostream &stream, T &&)
     {
         stream << demangle(typeid(T).name());
     }
@@ -497,17 +497,9 @@ struct ChannelInterface<R(T...)>
     // helper for Merge below
     using signature_return_type = R;
 
-    // Make sure we're a POD.
-    #ifdef CONDUIT_SOURCE_STRING_INTERNING
-    ChannelInterface(uint64_t id, Channel<R(T...)> *c) : source_id(id), channel(c)
-    {
-    }
-    #else
-    ChannelInterface(std::string id, Channel<R(T...)> *c) : source_id(id), channel(c)
-    {
-    }
-    #endif
-
+    //
+    // No special member function so we are an aggregate type
+    //
     ~ChannelInterface() = default;
 
     typename Channel<R(T...)>::OperatorReturn operator()(const T &...t) const

--- a/include/conduit/conduit.h
+++ b/include/conduit/conduit.h
@@ -227,7 +227,7 @@ struct Channel<R(T...)> final : public ChannelBase
             c.cb(t...);
         }
         in_callbacks = false;
-        if (pending_unsubscribe.size())
+        if (!pending_unsubscribe.empty())
             unsubscribe_();
 
         #ifdef CONDUIT_CHANNEL_TIMES
@@ -254,15 +254,15 @@ struct Channel<R(T...)> final : public ChannelBase
             ret.emplace_back(c.cb(t...));
         }
         in_callbacks = false;
-        if (pending_unsubscribe.size())
+        if (!pending_unsubscribe.empty())
             unsubscribe_();
 
-        if (resolves->size()) {
+        if (!resolves->empty()) {
             in_resolves = true;
             for (auto &r : *resolves)
                 r.cb(ret);
             in_resolves = false;
-            if (pending_unresolve.size())
+            if (!pending_unresolve.empty())
                 unresolve_();
         }
 
@@ -1088,7 +1088,6 @@ struct Registrar
     RegistryEntry<T> &find(const std::string &name)
     {
         auto ti = std::type_index(typeid(T));
-        Channel<T> *channel = nullptr;
         if (!map[name]) {
             auto re = std::make_unique<RegistryEntry<T>>(*this);
             re->ti = ti;

--- a/include/conduit/conduit.h
+++ b/include/conduit/conduit.h
@@ -147,7 +147,7 @@ namespace detail
     }
 
     template <typename T>
-    typename std::enable_if<!detail::has_putto_operator<T>::value>::type print_arg(std::ostream &stream, T &&t)
+    typename std::enable_if<!detail::has_putto_operator<T>::value>::type print_arg(std::ostream &stream, __attribute__ ((unused)) T &&t)
     {
         stream << demangle(typeid(T).name());
     }
@@ -498,7 +498,16 @@ struct ChannelInterface<R(T...)>
     using signature_return_type = R;
 
     // Make sure we're a POD.
-    ChannelInterface() = default;
+    #ifdef CONDUIT_SOURCE_STRING_INTERNING
+    ChannelInterface(uint64_t id, Channel<R(T...)> *c) : source_id(id), channel(c)
+    {
+    }
+    #else
+    ChannelInterface(std::string id, Channel<R(T...)> *c) : source_id(id), channel(c)
+    {
+    }
+    #endif
+
     ~ChannelInterface() = default;
 
     typename Channel<R(T...)>::OperatorReturn operator()(const T &...t) const
@@ -794,8 +803,8 @@ struct View<R(T...)> : ViewBase
     template <typename U, typename V, typename Ret, typename ...Args>
     std::enable_if_t<IsTuple<typename CallableInfo<V>::return_type>::value> set_subscribe_function(ChannelInterface<U> ci, V &&v, Ret(*)(Args...))
     {
-        subscribe_function = [=] (conduit::Function<R(const T &...)> cb, std::string name) {
-            ci.channel->registrar.template subscribe<U>(ci, [=] (const Args &...args) {
+        subscribe_function = [this, ci, v] (conduit::Function<R(const T &...)> cb, std::string name) {
+            ci.channel->registrar.template subscribe<U>(ci, [this, cb, v] (const Args &...args) {
                 return this->apply(cb, v(args...), std::make_index_sequence<std::tuple_size<typename CallableInfo<V>::return_type>::value>{});
             }, name);
         };

--- a/include/conduit/conduit.h
+++ b/include/conduit/conduit.h
@@ -215,8 +215,9 @@ struct Channel<R(T...)> final : public ChannelBase
     template <typename R_ = R, typename EnableRet = typename std::enable_if<std::is_same<R_, void>::value>::type>
     void operator()(const T &...t)
     {
-        if (callbacks->empty())
+        if (callbacks->empty()) {
             return;
+        }
 
         #ifdef CONDUIT_CHANNEL_TIMES
         auto start = std::chrono::high_resolution_clock::now();
@@ -227,8 +228,9 @@ struct Channel<R(T...)> final : public ChannelBase
             c.cb(t...);
         }
         in_callbacks = false;
-        if (!pending_unsubscribe.empty())
+        if (!pending_unsubscribe.empty()) {
             unsubscribe_();
+        }
 
         #ifdef CONDUIT_CHANNEL_TIMES
         auto end = std::chrono::high_resolution_clock::now();
@@ -240,8 +242,9 @@ struct Channel<R(T...)> final : public ChannelBase
     template <typename R_ = R, typename EnableRet = typename std::enable_if<!std::is_same<R_, void>::value, R_>::type>
     std::vector<conduit::Optional<R>> operator()(const T &... t)
     {
-        if (callbacks->empty())
+        if (callbacks->empty()) {
             return std::vector<conduit::Optional<R>>();
+        }
 
         ret.clear();
 
@@ -254,16 +257,19 @@ struct Channel<R(T...)> final : public ChannelBase
             ret.emplace_back(c.cb(t...));
         }
         in_callbacks = false;
-        if (!pending_unsubscribe.empty())
+        if (!pending_unsubscribe.empty()) {
             unsubscribe_();
+        }
 
         if (!resolves->empty()) {
             in_resolves = true;
-            for (auto &r : *resolves)
+            for (auto &r : *resolves) {
                 r.cb(ret);
+            }
             in_resolves = false;
-            if (!pending_unresolve.empty())
+            if (!pending_unresolve.empty()) {
                 unresolve_();
+            }
         }
 
         #ifdef CONDUIT_CHANNEL_TIMES
@@ -292,8 +298,9 @@ private:
         auto pos = std::find_if(callbacks->begin(), callbacks->end(), [client_name] (struct Channel<R(T...)>::Callback &cb) {
             return cb.name == client_name;
         });
-        if (pos == callbacks->end())
+        if (pos == callbacks->end()) {
             return;
+        }
         pending_unsubscribe.push_back(std::distance(callbacks->begin(), pos));
         if (!in_callbacks) {
             unsubscribe_();
@@ -302,8 +309,9 @@ private:
 
     void unsubscribe(size_t index)
     {
-        if (index < callbacks->size())
+        if (index < callbacks->size()) {
             pending_unsubscribe.push_back(index);
+        }
         if (!in_callbacks) {
             unsubscribe_();
         }
@@ -326,8 +334,9 @@ private:
         auto pos = std::find_if(resolves->begin(), resolves->end(), [client_name] (struct Channel<R(T...)>::Callback &cb) {
             return cb.name == client_name;
         });
-        if (pos == resolves->end())
+        if (pos == resolves->end()) {
             return;
+        }
         pending_unresolve.push_back(std::distance(resolves->begin(), pos));
         if (!in_callbacks) {
             unsubscribe_();
@@ -336,8 +345,9 @@ private:
 
     void unresolve(size_t index)
     {
-        if (index < resolves->size())
+        if (index < resolves->size()) {
             pending_unresolve.push_back(index);
+        }
         if (!in_callbacks) {
             unresolve_();
         }
@@ -499,8 +509,9 @@ struct ChannelInterface<R(T...)>
             detail::call_print_arg(CONDUIT_LOGGER, t...);
             CONDUIT_LOGGER << ")\n";
         }
-        if (c.callbacks->size() == 0)
+        if (c.callbacks->size() == 0) {
             return typename Channel<R(T...)>::OperatorReturn();
+        }
         return c(t...);
     }
 
@@ -574,8 +585,9 @@ struct OptupleImpl : Optuple
     void fire(std::index_sequence<I...>)
     {
         callback(detail::TupleGetVal<I>::get(data)...);
-        if (response)
+        if (response) {
             response();
+        }
         reset();
     }
 
@@ -1103,8 +1115,9 @@ struct Registrar
     // TODO: fix the recursive loop so that swap(pending_views, copy) isn't necessary
     void match_pending_views(std::string name)
     {
-        if (pending_views.find(name) == pending_views.end())
+        if (pending_views.find(name) == pending_views.end()) {
             return;
+        }
         decltype(pending_views) copy;
         using std::swap;
         swap(pending_views, copy);;

--- a/include/conduit/function.h
+++ b/include/conduit/function.h
@@ -84,8 +84,9 @@ public:
     {
         if (buf != nullptr) {
             destruct(buf);
-            if (buf != &internal_storage)
+            if (buf != &internal_storage) {
                 free(buf);
+            }
             buf = nullptr;
         }
     }
@@ -97,8 +98,9 @@ public:
 
     Function &operator =(const Function &o)
     {
-        if (this == &o)
+        if (this == &o) {
             return *this;
+        }
 
         this->~Function();
 
@@ -106,15 +108,17 @@ public:
         destruct = o.destruct;
         clone = o.clone;
 
-        if (o.clone != nullptr)
+        if (o.clone != nullptr) {
             o.clone(this, &o);
+        }
         return *this;
     }
 
     Function &operator =(Function &&o)
     {
-        if (this == &o)
+        if (this == &o) {
             return *this;
+        }
 
         this->~Function();
 

--- a/include/conduit/optional.h
+++ b/include/conduit/optional.h
@@ -74,7 +74,9 @@ struct Optional {
     Optional(OptionalNull &&) : engaged_(false) {}
     Optional(const Optional &o) : engaged_(o.engaged_)
     {
-        if (engaged_) new (&buf) T(*o);
+        if (engaged_) {
+            new (&buf) T(*o);
+        }
     }
     Optional(Optional &&o) noexcept(std::is_nothrow_move_constructible<T>::value) : engaged_(o.engaged_)
     {
@@ -98,19 +100,22 @@ struct Optional {
 
     Optional &operator=(const Optional &o)
     {
-        if (this == &o)
+        if (this == &o) {
             return *this;
+        }
         destroy();
         engaged_ = o.engaged_;
-        if (engaged_)
+        if (engaged_) {
             new (&buf) T(*o);
+        }
         return *this;
     }
 
     Optional &operator=(Optional &&o) noexcept(std::is_nothrow_move_constructible<T>::value)
     {
-        if (this == &o)
+        if (this == &o) {
             return *this;
+        }
         destroy();
         engaged_ = o.engaged_;
         if (engaged_) {

--- a/include/conduit/small-callable.h
+++ b/include/conduit/small-callable.h
@@ -96,14 +96,16 @@ public:
 
     SmallCallable(const SmallCallable &o) : mem_size(o.mem_size)
     {
-        if (o.mem_size)
+        if (o.mem_size) {
             o.holder_base->clone(reinterpret_cast<char *>(holder_base));
+        }
     }
 
     SmallCallable(SmallCallable &&o) : mem_size(o.mem_size)
     {
-        if (o.mem_size)
+        if (o.mem_size) {
             o.holder_base->clone(reinterpret_cast<char *>(holder_base));
+        }
     }
 
     template <typename V>
@@ -127,8 +129,9 @@ public:
 
     SmallCallable &operator=(const SmallCallable &o)
     {
-        if (this == &o)
+        if (this == &o) {
             return *this;
+        }
         destroy();
         o.holder_base->clone(reinterpret_cast<char *>(holder_base));
         mem_size = o.mem_size;


### PR DESCRIPTION
Make lambdas capture explicit to allow C++17 & C++20.
Make constructor explicit to support C++20.
Use curlies around all ifs to allow clang-tidy to run clean.
Add unused attribute to allow clang-tidy to run clean.